### PR TITLE
fix(vivo推送插件): 移除VivoReceiver中冗余的令牌发送调用

### DIFF
--- a/flutter_push_plugin_vivo/android/src/main/java/com/dcstudio/flutter_push_plugin_vivo/VivoReceiver.java
+++ b/flutter_push_plugin_vivo/android/src/main/java/com/dcstudio/flutter_push_plugin_vivo/VivoReceiver.java
@@ -10,7 +10,6 @@ public class VivoReceiver extends OpenClientPushMessageReceiver {
     @Override
     public void onReceiveRegId(Context context, String regId) {
         super.onReceiveRegId(context, regId);
-        IntentEventSender.sendTokenIntent(context, regId);
     }
 
     @Override


### PR DESCRIPTION
该调用与父类OpenClientPushMessageReceiver的处理逻辑重复，移除以避免重复发送注册令牌广播 
参照：https://dev.vivo.com.cn/documentCenter/doc/614